### PR TITLE
Remove redundant tls hosts / secret config

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -40,9 +40,4 @@ spec:
   {{- if .Values.uiIngress.spec.tls }}
     {{- .Values.uiIngress.spec.tls | toYaml | nindent 2 }}
   {{- end }}
-  {{- if .Values.uiIngress.tls.enabled }}
-  - hosts:
-      - {{ .Values.uiIngress.host }}
-    secretName: {{ include "seriohub-velero.fullname" . }}-api-tls
-  {{- end }}
 {{- end }}

--- a/chart/templates/ui/configmap.yaml
+++ b/chart/templates/ui/configmap.yaml
@@ -11,13 +11,8 @@ data:
   # Ingress
   #
   {{- if .Values.uiIngress.enabled }}
-  {{- if .Values.uiIngress.tls.enabled }}
   NEXT_PUBLIC_VELERO_API_URL: {{ printf "https://%s/api" .Values.uiIngress.host | quote }}
   NEXT_PUBLIC_VELERO_API_WS: {{ printf "wss://%s" .Values.uiIngress.host | quote }}
-  {{- else }}
-  NEXT_PUBLIC_VELERO_API_URL: {{ printf "http://%s/api" .Values.uiIngress.host | quote }}
-  NEXT_PUBLIC_VELERO_API_WS: {{ printf "ws://%s" .Values.uiIngress.host | quote }}
-  {{- end }}
   {{- end }}
   #  
   # NodePort

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -232,8 +232,6 @@ uiIngress:
   metadata:
     annotations:
       # cert-manager.io/cluster-issuer: "letsencrypt-prod"
-  tls:
-    enabled: true
   spec:
     tls:
     # - hosts:

--- a/test-values.yaml
+++ b/test-values.yaml
@@ -196,17 +196,14 @@ uiNp:
 uiIngress:
   enabled: true
   ingressClassName: gelan-pub
-  host: velero.svc.gelan-ict.ch
-  tls:
-    enabled: true
   metadata:
     annotations:
       # cert-manager.io/cluster-issuer: "letsencrypt-prod" 
   spec:
     tls:
-    # - hosts:
-    #   - velero-ui.domain.com
-    #   secretName: velero-ui-tls
+    - hosts:
+      - velero.svc.gelan-ict.ch
+      secretName: velero-ui-tls
 
 #
 # Service Account

--- a/values-override.yaml
+++ b/values-override.yaml
@@ -37,17 +37,14 @@ uiNp:
 uiIngress:
   enabled: false
   # ingressClassName: nginx
-  host: velero.<your-domain>
-  tls:
-    enabled: false
   # metadata:
   #   annotations:
   #     cert-manager.io/cluster-issuer: "letsencrypt-prod" 
-  # spec:
-  #   tls:
-  #    - hosts:
-  #      - velero-ui.domain.com
-  #      secretName: velero-ui-tls
+  spec:
+    tls:
+  #  - hosts:
+  #    - velero.<your-domain>
+  #    secretName: velero-ui-tls
 
 #
 # Watchdog Cron


### PR DESCRIPTION
This change is to remove the redundant config for tls certs.  Previously, the ingress pulls two tls hosts / secrets:

Method 1:
```
uiIngress:
  host: yourhost.com
  tls:
    enabled: true
```

Method 2:
```
uiIngress:
  spec:
    tls:
      - hosts:
        - yourhost.com
        secretName: your-secret-name
```

But only one is needed, and if you specify both it will create redundant certificates.  Removing the simplified method and keeping the more configurable one.