### PR TITLE
fix: typo in watchdogConfig

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -389,7 +389,7 @@ watchdogConfig:
   # -- Socket bind host
   apiEndpointURL: "0.0.0.0"
   # -- Socket bind port
-  apiEndPointPort: "8001"
+  apiEndpointPort: "8001"
   # -- View debugging information.
   debug: "False"
   # -- Debug level information.


### PR DESCRIPTION
Replace `apiEndPointPort` by `apiEndpointPort`

See https://github.com/seriohub/velero-helm/blob/main/chart/templates/watchdog/configmap.yaml#L12
